### PR TITLE
Delete ボタン機能の実装

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1121,37 +1121,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &908682800
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 908682801}
-  m_Layer: 0
-  m_Name: GameObject (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &908682801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 908682800}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &956867661
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -378,6 +378,7 @@ MonoBehaviour:
   - {fileID: 677619505}
   - {fileID: 1190452438}
   callButton: {fileID: 1916754290}
+  deleteButton: {fileID: 1191548343}
 --- !u!4 &328483055
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -1120,6 +1120,37 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &908682800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 908682801}
+  m_Layer: 0
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &908682801
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 908682800}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &956867661
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/NumberGameModel.cs
+++ b/Assets/Scripts/NumberGameModel.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using UniRx;
-using Unity.VisualScripting;
 
 [Serializable]
 public class NumberGameModel
@@ -119,7 +118,12 @@ public class NumberGameModel
         UnityEngine.Debug.Log($"デバッグ用の乱数入力値 : { string.Join(", ", InputNumberList)}");
     }
     
-    
-    // TODO ゲームのリセット機能
-    
+    /// <summary>
+    /// 入力した値を削除して、再度ゲームにチャレンジできる状態にする
+    /// </summary>
+    public void ClearInputNumbers() {
+        //InputNumbers.Clear();
+        
+        InputNumberList.Clear();
+    }
 }

--- a/Assets/Scripts/NumberGamePresenter.cs
+++ b/Assets/Scripts/NumberGamePresenter.cs
@@ -84,8 +84,22 @@ public class NumberGamePresenter : MonoBehaviour
             })
             .AddTo(disposables);
 
-        // TODO 削除ボタンのクリックイベントを購読
-
+        // 削除ボタンのクリックイベントを購読
+        view.OnDeleteButtonClickAsObservable
+            .Where(_ => model.InputNumberList.Count > 0)
+            .Subscribe(_ =>
+            {
+                // List の最後の要素を取り出す(Linq)
+                int deletedNumber = model.InputNumberList.Last();
+                model.RemoveLastInputNumber();
+        
+                // 削除したボタンを有効にする
+                view.EnableNumberButton(deletedNumber);
+        
+                view.UpdateInputDisplay(model.InputNumberList);
+                Debug.Log(deletedNumber);
+            })
+            .AddTo(disposables);
 
         // Call ボタンのクリックイベントを購読
         // 上の処理で Call ボタンのオン・オフ切り替えをしているため、ここでは Subscribe のみでよい
@@ -103,6 +117,16 @@ public class NumberGamePresenter : MonoBehaviour
             .ToReactiveCommand() // bool型のストリームをReactiveCommandに変換
             .BindTo(view.CallButton) // その後BindToを使ってViewクラスのCallButtonプロパティに紐づけ
             .AddTo(disposableModels);
+        
+        // ReactiveCollection クリア時の処理が必要な場合には追加
+        model.InputNumberList.ObserveReset()
+            .Subscribe(_ =>
+            {
+                view.UpdateInputDisplay(model.InputNumberList);
+                view.SwitchAllButtons(true);
+                Debug.Log("Clear");
+            })
+            .AddTo(disposableModels);
 
         // GameState の購読
         model.CurrentNumberGameState
@@ -114,6 +138,9 @@ public class NumberGamePresenter : MonoBehaviour
                 Debug.Log("GameState : " + state);
             })
             .AddTo(disposableModels);
+        
+        // TODO チャレンジ回数の購読
+        
         
     }
     

--- a/Assets/Scripts/NumberGameView.cs
+++ b/Assets/Scripts/NumberGameView.cs
@@ -25,10 +25,13 @@ public class NumberGameView : MonoBehaviour
     public IObservable<int> OnNumberButtonClickAsObservable => numberButtonList.Select((button, index) => button.OnClickAsObservable().Select(_ => index)).Merge();
     
     [SerializeField] private Button callButton;
+    [SerializeField] private Button deleteButton;
+        
     public Button CallButton => callButton;  // プロパティ
     
     // OnClickAsObservable()の購読処理を施したボタンのプロパティ
     public IObservable<Unit> OnCallButtonClickAsObservable => callButton.OnClickAsObservable();
+    public IObservable<Unit> OnDeleteButtonClickAsObservable => deleteButton.OnClickAsObservable();
     
     
     void Start() {
@@ -71,8 +74,8 @@ public class NumberGameView : MonoBehaviour
     /// 全数字ボタンの状態の切り替え
     /// </summary>
     /// <param name="isSwitch"></param>
-    public void SwitchAllButtons(bool isSwitch) {
-
+    public void SwitchAllButtons(bool isSwitch) 
+    {
         for (int i = 0; i < numberButtonList.Count; i++) {
             numberButtonList[i].interactable = isSwitch;
         }

--- a/Assets/Scripts/NumberGameView.cs
+++ b/Assets/Scripts/NumberGameView.cs
@@ -28,6 +28,7 @@ public class NumberGameView : MonoBehaviour
     [SerializeField] private Button deleteButton;
         
     public Button CallButton => callButton;  // プロパティ
+    public Button DeleteButton => deleteButton;  // プロパティ
     
     // OnClickAsObservable()の購読処理を施したボタンのプロパティ
     public IObservable<Unit> OnCallButtonClickAsObservable => callButton.OnClickAsObservable();

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -6,6 +6,6 @@ EditorBuildSettings:
   serializedVersion: 2
   m_Scenes:
   - enabled: 1
-    path: Assets/Scenes/SampleScene.unity
+    path: Assets/Scenes/Main.unity
     guid: 8c9cfa26abfee488c85f1582747f6a02
   m_configObjects: {}


### PR DESCRIPTION
・View、Presenter を修正し、数字削除ボタンに再度に入力した数字１つを削除する機能を購読イベントとして実装。

・数字削除確認。数字が削除されて３つの値がない場合には Call ボタンが押せなくなる制御の確認。
　Model を修正し、Call した際、不正解の場合には入力した値がクリアされる機能を追加。
　View と Presenter を修正し、数字が入力されていない場合には Delete ボタンを押せなくする機能を追加。

・デバッグ完了。